### PR TITLE
Removing anaconda from environment.yml

### DIFF
--- a/envs/environment.yml
+++ b/envs/environment.yml
@@ -1,7 +1,7 @@
 name: mwf_env
 channels:
-  - anaconda
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.9
   # Use pyyaml to read the inputs.yaml file


### PR DESCRIPTION
Hi! Recently we've discovered that, in some centres, Anaconda is not allowed due to licensing restrictions:

https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us

As all the dependencies currently used in this repo are available in conda-forge and bioconda, we can easily bypass this issue by removing the _anaconda_ channel and specifying _nodefaults_ for avoiding the conda defaults channel:

```
name: mwf_env
channels:
  - conda-forge
  - nodefaults
```

Please check that this change works in all your test environments and let me know once it has been included in the master branch in order to integrate it to all the nodes.

Best.